### PR TITLE
MAINT Correctly order `SHOTComputer` constructor arguments

### DIFF
--- a/include/shot_descriptor.h
+++ b/include/shot_descriptor.h
@@ -148,8 +148,8 @@ public:
   explicit SHOTComputer(
     float radius = 15,
     float localRFradius = 15,
-    float bins = 10,
     int minNeighbors = 10,
+    float bins = 10,
     double doubleVolumes=true,
     double useInterpolation=true,
     double useNormalization=true
@@ -230,15 +230,15 @@ private:
  * @param vertices (n, 3) array of vertex locations.
  * @param faces (m, 3) array of triangular faces indices.
  * @param radius Radius for querying neighbours.
- * @param local_rf_radius Radius of the Reference Frame neighbourhood.
- * @param min_neighbors The minimum number of neighbours to use.
- * @param n_bins Number of bins for the histogram
+ * @param localRFradius Radius of the Reference Frame neighbourhood.
+ * @param minNeighbors The minimum number of neighbours to use.
+ * @param bins Number of bins for the histogram
  * @param double_volumes Double the maximum number of volume angular sectors
    for descriptor.
  * @param use_interpolation Use interpolation during computations.
  * @param use_normalization Normalize during computations.
  * @return (n, d) array containing the d SHOT descriptors for the n points,
-   where d = 16 * (n_bins + 1) * (double_volumes + 1).
+   where d = 16 * (bins + 1) * (double_volumes + 1).
  */
 std::vector<std::vector<double > >  calc_shot(
                const std::vector<std::vector<double> >& vertices,

--- a/pyshot.pyx
+++ b/pyshot.pyx
@@ -8,13 +8,13 @@ from libcpp cimport bool
 
 cdef extern from "include/shot_descriptor.h":
 
-    vector[vector[double]]  calc_shot(
+    vector[vector[double]] calc_shot(
                    const vector[vector[double]] vertices,
                    const vector[vector[int]] faces,
                    double radius,
-                   double localRFradius,
-                   int minNeighbors,
-                   int bins,
+                   double local_rf_radius,
+                   int min_neighbors,
+                   int n_bins,
                    bool double_volumes,
                    bool use_interpolation,
                    bool use_normalization,
@@ -59,8 +59,7 @@ cpdef get_descriptors(
     ----------
     descr: (n, d) float
       Array containing the d SHOT descriptors for the n points,
-      where d = 16 * (n_bins + 1) * (double_volumes + 1).
-
+      where d = 16 * (n_bins + 1) * (double_volumes_sectors + 1).
     """
 
     descr = calc_shot(vertices,

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pyshot
+import pytest
+
+@pytest.mark.parametrize("radius", [0.9, 1.1])
+@pytest.mark.parametrize("n_bins", [10, 20, 100])
+@pytest.mark.parametrize("min_neighbors", [3, 5, 6])
+@pytest.mark.parametrize("double_volumes_sectors", [True, False])
+def test_descriptors_shape(radius, n_bins, min_neighbors, double_volumes_sectors):
+
+    verts = np.random.rand(5000, 3)
+    faces = np.random.choice(5000, size=(10000, 3), replace=True)
+
+    shot_features = pyshot.get_descriptors(
+                verts,
+                faces,
+                radius=radius,
+                local_rf_radius=radius,
+                min_neighbors=min_neighbors,
+                n_bins=n_bins,
+                double_volumes_sectors=double_volumes_sectors,
+                use_interpolation=True,
+                use_normalization=True,
+    )
+
+    n_features = 16 * (n_bins + 1) * (double_volumes_sectors + 1)
+
+    assert shot_features.shape[1] == n_features


### PR DESCRIPTION
Fixes https://github.com/uhlmanngroup/pyshot/issues/2.